### PR TITLE
Fix - Wrong NTSC-J game

### DIFF
--- a/docs/files/ntsc-j-exclusives-games.txt
+++ b/docs/files/ntsc-j-exclusives-games.txt
@@ -14,7 +14,7 @@
 | J. League Live 64                                    | J-League Tactics Soccer                                 | Jango Simulation Mahjong-do 64                                |
 | Jikkyō GI Stable                                     | Jikkyō Pawapuro Puroyakyu 4                             | Jikkyō Pawapuro Puroyakyu 5                                   |
 | Jikkyō Pawapuro Puroyakyu 6                          | Jikkyō Pawapuro Puroyakyu 2000                          | Jikkyō Powerful Pro Yakyu Basic-ban 2001                      |
-| Jinsei Game 64                                       | Jikkyō World Soccer 3                                   | Kasutamu Robo                                                 |
+| Jinsei Game 64                                       | Jikkyō J-League Perfect Striker                         | Kasutamu Robo                                                 |
 | Kasutamu Robo Buitsū                                 | Kiratto Kaiketsu! 64 Tanteidan                          | Last Legion UX                                                |
 | Mahjong 64                                           | Mahjong Horoki Classic                                  | Mahjong Master                                                |
 | Mario no Photopi                                     | Morita Shogi 64                                         | Neon Genesis Evangelion                                       |

--- a/docs/ntsc-j-exclusives.md
+++ b/docs/ntsc-j-exclusives.md
@@ -10,5 +10,5 @@ All games that were released only in Japan.
 
 ## Download links
 
-- [Labels in PNG format (to print)](files/ntsc-j-exclusives-images.zip) - **[Updated 2023/10/07]**
-- [Labels in PSD format (to edit)](files/ntsc-j-exclusives-templates.zip) - **[Updated 2023/10/07]**
+- [Labels in PNG format (to print)](files/ntsc-j-exclusives-images.zip) - **[Updated 2023/12/04]**
+- [Labels in PSD format (to edit)](files/ntsc-j-exclusives-templates.zip) - **[Updated 2023/12/04]**


### PR DESCRIPTION
The Wikipedia article is wrong, `Jikkyō World Soccer 3` is `ISS64`. `Perfect Striker` is exclusive. 