### PR TITLE
Chore - Redo NTSC-J Mystical Ninja Starring Goemon

### DIFF
--- a/docs/ntsc-j.md
+++ b/docs/ntsc-j.md
@@ -10,5 +10,5 @@ All games that were released in Japan.
 
 ## Download links
 
-- [Labels in PNG format (to print)](files/ntsc-j-images.zip) - **[Updated 2023/10/07]**
-- [Labels in PSD format (to edit)](files/ntsc-j-templates.zip) - **[Updated 2023/10/07]**
+- [Labels in PNG format (to print)](files/ntsc-j-images.zip) - **[Updated 2026/08/09]**
+- [Labels in PSD format (to edit)](files/ntsc-j-templates.zip) - **[Updated 2026/08/09]**


### PR DESCRIPTION
Label for `Mystical Ninja Starring Goemon` was upscaled using AI due to very low source image resolution. Found higher quality scans and did a good touch up on Photoshop. 